### PR TITLE
Simplify tail request

### DIFF
--- a/app/Adapter/Routing/WS/Post.js
+++ b/app/Adapter/Routing/WS/Post.js
@@ -24,16 +24,9 @@ class PostController {
           }
 
           switch (true) {
-            case !!(threadId && page && page.toLowerCase() === 'tail'):
-              // tail (last posts in the thread)
-              posts = await this.post.readThreadTail(threadId, {count});
-              break;
             case !!(threadId && !boardName):
               // just posts in a thread
               page = +page;
-              if (page < 0) {
-                throw new BadRequestError("Page must not be lower than 0");
-              }
               posts = await this.post.readThreadPosts(threadId, {count, page});
               break;
             case !!(!threadId && boardName):

--- a/app/Application/Business/PostBO.js
+++ b/app/Application/Business/PostBO.js
@@ -20,13 +20,10 @@ class PostBO {
     return this.process(post);
   }
 
-  async readThreadTail(threadId, { count } = {}) {
-    let posts = await this.PostService.readThreadTail(threadId, { count });
-    return Tools.parallel(this.process.bind(this), posts);
-  }
-
   async readThreadPosts(threadId, { count, page } = {}) {
-    let posts = await this.PostService.readThreadPosts(threadId, { count, page });
+    let posts = page >= 0
+      ? await this.PostService.readThreadPosts(threadId, { count, page })
+      : await this.PostService.readThreadTail(threadId, { count });
     return Tools.parallel(this.process.bind(this), posts);
   }
 


### PR DESCRIPTION
`tail` is a special value for the `page` argument used to get *last* posts from a thread. By treating all negative numbers as a signal to return posts from the end instead, we can simplify the API in terms of valid values:

<table>
<tr>
	<td>Before
	<td>After
<tr>
	<td>Any non-negative whole number or "tail" string
	<td>Any whole number
</table>