### PR TITLE
Remove cyclic relations between post and thread entities in DB

### DIFF
--- a/app/Application/Business/PostBO.js
+++ b/app/Application/Business/PostBO.js
@@ -19,12 +19,14 @@ class PostBO {
   }
 
   async createPreHook(postDTO, threadDTO) {
-    let Thread;
-    if (threadDTO) {
-      Thread = await this.ThreadService.create(threadDTO);
-      postDTO.threadId = Thread.id;
+    if (!threadDTO) {
+      return [postDTO, undefined];
     }
-    return [postDTO, Thread];
+
+    const thread = await this.ThreadService.create(threadDTO);
+    postDTO.threadId = thread.id;
+    postDTO.isHead = true;
+    return [postDTO, thread]
   }
 
   /**

--- a/app/Domain/DTO/PostDTO.js
+++ b/app/Domain/DTO/PostDTO.js
@@ -25,6 +25,7 @@ class PostDTO extends DTO {
     this.sessionKey = data.sessionKey;
     this.modifiers = data.modifiers || [];
     this.ipAddress = data.ipAddress;
+    this.isHead = data.isHead;
     this.created = data.created;
     this.updated = data.updated;
     this.deleted = data.deleted;

--- a/db/migrations/000_initial.js
+++ b/db/migrations/000_initial.js
@@ -58,6 +58,7 @@ exports.up = knex => {
       table.increments('id').unsigned().primary();
       table.integer('threadId').unsigned().notNullable();
       table.integer('userId').unsigned();
+      table.boolean('isHead');
       table.integer('number').unsigned();
       table.string('subject', 60);
       table.text('text');

--- a/db/seeds/000_initial.js
+++ b/db/seeds/000_initial.js
@@ -49,6 +49,7 @@ exports.seed = async knex => {
   ]).into('thread');
   await knex.withSchema(schema).insert([
     {
+      isHead: true,
       threadId: 1,
       userId: 1,
       number: 1,
@@ -60,6 +61,7 @@ exports.seed = async knex => {
       text: 'id 2, /t/, thread 1, post 2'
     },
     {
+      isHead: true,
       threadId: 2,
       number: 1,
       text: 'id 3, /test/, thread 2, post 1, OP'
@@ -75,31 +77,37 @@ exports.seed = async knex => {
       text: 'id 5, /test/, thread 2, post 2'
     },
     {
+      isHead: true,
       threadId: 3,
       number: 4,
       text: 'id 6, /t/, thread 3, post 4, OP'
     },
     {
+      isHead: true,
       threadId: 4,
       number: 3,
       text: 'id 7, /test/, thread 4, post 3, OP'
     },
     {
+      isHead: true,
       threadId: 5,
       number: 5,
       text: 'id 8, /t/, thread 5, post 5, OP'
     },
     {
+      isHead: true,
       threadId: 6,
       number: 4,
       text: 'id 9, /test/, thread 6, post 4, OP'
     },
     {
+      isHead: true,
       threadId: 7,
       number: 6,
       text: 'id 10, /t/, thread 7, post 6, OP'
     },
     {
+      isHead: true,
       threadId: 8,
       number: 5,
       text: 'id 11, /test/, thread 8, post 5, OP'


### PR DESCRIPTION
This PR fixes the cyclic relations situation between post and thread entities by adding a boolean variable isHead to post entity.
![image](https://user-images.githubusercontent.com/82229068/188933595-1b0400c6-48e3-4088-b192-1c6545b73867.png)
